### PR TITLE
Add list support for Magic Links

### DIFF
--- a/Editor/Main/MagicLinksScriptsGenerator.cs
+++ b/Editor/Main/MagicLinksScriptsGenerator.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
@@ -34,9 +35,21 @@ namespace MagicLinks
 
             string variables = string.Empty;
 
+            var listTypes = new HashSet<string>();
+            foreach (var v in MagicLinksInternalVar.GetExistingVariables())
+            {
+                if (!v.IsEvent() && v.isList)
+                    listTypes.Add(v.vLabelType);
+            }
+
             foreach (string customType in MagicLinksUtilities.GetAllTypes())
             {
                 variables += GetDict(MagicLinksConst.VariableDictTemplate, customType, customType.ToUpper());
+            }
+
+            foreach (string listType in listTypes)
+            {
+                variables += GetDict(MagicLinksConst.ListDictTemplate, listType, listType.ToUpper() + MagicLinksConst.ListSuffix);
             }
 
             variables += "\n \n";
@@ -63,6 +76,11 @@ namespace MagicLinks
             foreach (string customType in MagicLinksUtilities.GetAllTypes())
             {
                 variablesGetter += GetDict(MagicLinksConst.VariableGetterTemplate, customType, customType.ToUpper());
+            }
+
+            foreach (string listType in listTypes)
+            {
+                variablesGetter += GetDict(MagicLinksConst.VariableGetterTemplate, $"List<{listType}>", listType.ToUpper() + MagicLinksConst.ListSuffix);
             }
 
             classContent = classContent.Replace("//MAGICVARIABLESGETTER", variablesGetter);

--- a/Editor/Utilities/MagicLinksConst.cs
+++ b/Editor/Utilities/MagicLinksConst.cs
@@ -15,6 +15,7 @@ namespace MagicLinks
         public const string VariablesResourcesPath = "MagicLinks/Links/";
 
         public const string EventDict = "_EVENT";
+        public const string ListSuffix = "_LIST";
 
         public const string EventListenerName = "_EventListener";
         public const string VariableListenerName = "_VariableListener";
@@ -56,6 +57,8 @@ namespace MagicLinks
 
         public const string VariableDictTemplate =
             "public Dictionary<string, MagicVariableObservable<TYPE>> NAME = new();";
+        public const string ListDictTemplate =
+            "public Dictionary<string, MagicVariableObservable<List<TYPE>>> NAME = new();";
 
         public const string EventDictTemplate = "public Dictionary<string, MagicEventObservable<TYPE>> NAME = new();";
         public const string EventVoidDictTemplate = "public Dictionary<string, MagicEventVoidObservable> VOID = new();";
@@ -104,6 +107,9 @@ namespace MagicLinks
 
         public static string GetRuntimeField(string t)
         {
+            if (t.StartsWith("List", StringComparison.Ordinal))
+                return UXMLRuntimeFieldsUIPath + "list.uxml";
+
             return UXMLRuntimeFieldsUIPath + t.ToLower() + ".uxml";
         }
     }

--- a/Editor/Utilities/MagicLinksUtilities.cs
+++ b/Editor/Utilities/MagicLinksUtilities.cs
@@ -111,6 +111,17 @@ namespace MagicLinks
             baseTypes.Add(MagicLinksConst.Collider, typeof(Collider).ToString());
             baseTypes.Add(MagicLinksConst.Color, typeof(Color).ToString());
 
+            baseTypes.Add("ListString", typeof(List<string>).ToString());
+            baseTypes.Add("ListBool", typeof(List<bool>).ToString());
+            baseTypes.Add("ListInt", typeof(List<int>).ToString());
+            baseTypes.Add("ListFloat", typeof(List<float>).ToString());
+            baseTypes.Add("ListVector2", typeof(List<Vector2>).ToString());
+            baseTypes.Add("ListVector3", typeof(List<Vector3>).ToString());
+            baseTypes.Add("ListGameObject", typeof(List<GameObject>).ToString());
+            baseTypes.Add("ListTransform", typeof(List<Transform>).ToString());
+            baseTypes.Add("ListCollider", typeof(List<Collider>).ToString());
+            baseTypes.Add("ListColor", typeof(List<Color>).ToString());
+
             return baseTypes;
         }
 

--- a/Editor/Various/DynamicVariable.cs
+++ b/Editor/Various/DynamicVariable.cs
@@ -10,6 +10,7 @@ namespace MagicLinks
         public string initialValue;
         public int magicType;
         public string category;
+        public bool isList;
 
         public bool IsEvent()
         {

--- a/Runtime/UI/Fields/list.uxml
+++ b/Runtime/UI/Fields/list.uxml
@@ -1,0 +1,4 @@
+<engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/MagicLinks/Runtime/UI/RuntimeStyles.uss?fileID=7433441132597879392&amp;guid=55df091c6293b284d87a8e3904edd3fb&amp;type=3#RuntimeStyles" />
+    <engine:ListView name="Field" class="field" />
+</engine:UXML>

--- a/Runtime/UI/Fields/list.uxml.meta
+++ b/Runtime/UI/Fields/list.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4876b96eeb784ef896237322b0b0e1fe
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
## Summary
- support list variables with `isList` flag
- generate list dictionaries and getters
- include list types in base types
- expose generic ListView field for runtime UI
- adjust runtime handling of list variables

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb70adbec83328f034f0520b51114