### PR TITLE
Add list variable support

### DIFF
--- a/Editor/Main/MagicLinksInternalVar.cs
+++ b/Editor/Main/MagicLinksInternalVar.cs
@@ -32,6 +32,7 @@ namespace MagicLinks
 
             newVariable.vPath = newVariablePath;
             newVariable.category = MagicLinksConst.CategoryNone;
+            newVariable.isList = false;
 
             File.WriteAllText(newVariablePath, JsonUtility.ToJson(newVariable, true));
             AssetDatabase.Refresh();
@@ -123,7 +124,9 @@ namespace MagicLinks
                     lastCategory = v.category;
                 }
                 
-                config.typesNamesPairs.Add(new MagicLinkTypeNamePair(v.IsVoid() ? string.Empty : v.vLabelType, v.vName));
+                string typeName = v.vLabelType;
+                if (v.isList) typeName = $"List<{typeName}>";
+                config.typesNamesPairs.Add(new MagicLinkTypeNamePair(v.IsVoid() ? string.Empty : typeName, v.vName));
                 
                 //Filter
                 if (currentCategorySelected != MagicLinksConst.CategoryNone)
@@ -156,6 +159,10 @@ namespace MagicLinks
                         OnSingleVariableTypeChanged(v, newType.newValue);
                     });
                 }
+
+                Toggle listToggle = newUIVariable.Q<Toggle>(MagicLinksConst.SingleVariableIsList);
+                listToggle.SetValueWithoutNotify(v.isList);
+                listToggle.RegisterValueChangedCallback(evt => { OnIsListChanged(v, evt.newValue); });
 
                 DropdownField magicType = newUIVariable.Q<DropdownField>(MagicLinksConst.SingleVariableMagicType);
 
@@ -215,6 +222,16 @@ namespace MagicLinks
         {
             DynamicVariable variableToUpdate = JsonUtility.FromJson<DynamicVariable>(File.ReadAllText(variable.vPath));
             variableToUpdate.magicType = newMagicType;
+            File.WriteAllText(variable.vPath, JsonUtility.ToJson(variableToUpdate, true));
+
+            AssetDatabase.Refresh();
+            UpdateVariablesUI();
+        }
+
+        public static void OnIsListChanged(DynamicVariable variable, bool isList)
+        {
+            DynamicVariable variableToUpdate = JsonUtility.FromJson<DynamicVariable>(File.ReadAllText(variable.vPath));
+            variableToUpdate.isList = isList;
             File.WriteAllText(variable.vPath, JsonUtility.ToJson(variableToUpdate, true));
 
             AssetDatabase.Refresh();

--- a/Editor/Main/MagicLinksInternalVar.cs
+++ b/Editor/Main/MagicLinksInternalVar.cs
@@ -161,8 +161,16 @@ namespace MagicLinks
                 }
 
                 Toggle listToggle = newUIVariable.Q<Toggle>(MagicLinksConst.SingleVariableIsList);
-                listToggle.SetValueWithoutNotify(v.isList);
-                listToggle.RegisterValueChangedCallback(evt => { OnIsListChanged(v, evt.newValue); });
+
+                if (v.IsVoid() == false)
+                {
+                    listToggle.SetValueWithoutNotify(v.isList);
+                    listToggle.RegisterValueChangedCallback(evt => { OnIsListChanged(v, evt.newValue); });
+                }
+                else
+                {
+                    listToggle.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+                }
 
                 DropdownField magicType = newUIVariable.Q<DropdownField>(MagicLinksConst.SingleVariableMagicType);
 

--- a/Editor/Main/MagicLinksInternalVar.cs
+++ b/Editor/Main/MagicLinksInternalVar.cs
@@ -161,6 +161,7 @@ namespace MagicLinks
                 }
 
                 Toggle listToggle = newUIVariable.Q<Toggle>(MagicLinksConst.SingleVariableIsList);
+                Label isListLabel = newUIVariable.Q<Label>(MagicLinksConst.SingleVariableIsListLabel);
 
                 if (v.IsVoid() == false)
                 {
@@ -170,6 +171,7 @@ namespace MagicLinks
                 else
                 {
                     listToggle.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+                    isListLabel.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
                 }
 
                 DropdownField magicType = newUIVariable.Q<DropdownField>(MagicLinksConst.SingleVariableMagicType);

--- a/Editor/Main/MagicLinksScriptsGenerator.cs
+++ b/Editor/Main/MagicLinksScriptsGenerator.cs
@@ -37,6 +37,7 @@ namespace MagicLinks
             foreach (string customType in MagicLinksUtilities.GetAllTypes())
             {
                 variables += GetDict(MagicLinksConst.VariableDictTemplate, customType, customType.ToUpper());
+                variables += GetDict(MagicLinksConst.ListVariableDictTemplate, customType, customType.ToUpper() + MagicLinksConst.ListDict);
             }
 
             variables += "\n \n";
@@ -45,6 +46,8 @@ namespace MagicLinks
             {
                 variables += GetDict(MagicLinksConst.EventDictTemplate, customType,
                     customType.ToUpper() + MagicLinksConst.EventDict);
+                variables += GetDict(MagicLinksConst.ListEventDictTemplate, customType,
+                    customType.ToUpper() + MagicLinksConst.ListDict + MagicLinksConst.EventDict);
             }
 
             variables += MagicLinksConst.EventVoidDictTemplate;
@@ -63,6 +66,7 @@ namespace MagicLinks
             foreach (string customType in MagicLinksUtilities.GetAllTypes())
             {
                 variablesGetter += GetDict(MagicLinksConst.VariableGetterTemplate, customType, customType.ToUpper());
+                variablesGetter += GetDict(MagicLinksConst.ListVariableGetterTemplate, customType, customType.ToUpper() + MagicLinksConst.ListDict);
             }
 
             classContent = classContent.Replace("//MAGICVARIABLESGETTER", variablesGetter);
@@ -79,6 +83,13 @@ namespace MagicLinks
                 eventsGetter = regex.Replace(eventsGetter, MagicLinksConst.EventDict, 1);
 
                 eventsGetter += eventGetter;
+
+                string listEventGetter = GetDict(MagicLinksConst.ListEventGetterTemplate, customType,
+                    customType.ToUpper() + MagicLinksConst.ListDict + MagicLinksConst.EventDict);
+
+                listEventGetter = listEventGetter.Replace("SHORT", customType.ToUpper() + MagicLinksConst.ListDict);
+
+                eventsGetter += listEventGetter;
             }
 
             eventsGetter += MagicLinksConst.EventVoidGetterTemplate;

--- a/Editor/UI/Variable.uxml
+++ b/Editor/UI/Variable.uxml
@@ -5,6 +5,7 @@
         <engine:Label text="Variable name" name="Name" selectable="true" class="singleVariableElement" style="-unity-font-style: bold; width: auto; min-width: 200px;" />
         <engine:DropdownField name="MagicType" index="0" class="singleVariableElement minSize" />
         <engine:DropdownField name="Type" class="singleVariableElement minSize" />
+        <engine:Label text="Is List" name="IsListLabel" class="singleVariableElement" />
         <engine:Toggle name="IsList" class="singleVariableElement" />
         <engine:DropdownField name="Category" choices="Player,Enemy" index="0" class="singleVariableElement minSize" />
         <engine:Button text="x" name="DeleteButton" class="singleVariableElement" style="-unity-font-style: bold; background-color: rgb(188, 71, 71);" />

--- a/Editor/UI/Variable.uxml
+++ b/Editor/UI/Variable.uxml
@@ -5,6 +5,7 @@
         <engine:Label text="Variable name" name="Name" selectable="true" class="singleVariableElement" style="-unity-font-style: bold; width: auto; min-width: 200px;" />
         <engine:DropdownField name="MagicType" index="0" class="singleVariableElement minSize" />
         <engine:DropdownField name="Type" class="singleVariableElement minSize" />
+        <engine:Toggle name="IsList" class="singleVariableElement" />
         <engine:DropdownField name="Category" choices="Player,Enemy" index="0" class="singleVariableElement minSize" />
         <engine:Button text="x" name="DeleteButton" class="singleVariableElement" style="-unity-font-style: bold; background-color: rgb(188, 71, 71);" />
     </engine:VisualElement>

--- a/Editor/Utilities/MagicLinksConst.cs
+++ b/Editor/Utilities/MagicLinksConst.cs
@@ -101,6 +101,7 @@ namespace MagicLinks
         public const string SingleVariableCategory = "Category";
         public const string SingleVariableType = "Type";
         public const string SingleVariableIsList = "IsList";
+        public const string SingleVariableIsListLabel = "IsListLabel";
         public const string SingleVariableDeleteButton = "DeleteButton";
 
         public const string CustomTypesFoldout = "CustomTypesFoldout";

--- a/Editor/Utilities/MagicLinksConst.cs
+++ b/Editor/Utilities/MagicLinksConst.cs
@@ -15,6 +15,7 @@ namespace MagicLinks
         public const string VariablesResourcesPath = "MagicLinks/Links/";
 
         public const string EventDict = "_EVENT";
+        public const string ListDict = "_LIST";
 
         public const string EventListenerName = "_EventListener";
         public const string VariableListenerName = "_VariableListener";
@@ -57,14 +58,24 @@ namespace MagicLinks
         public const string VariableDictTemplate =
             "public Dictionary<string, MagicVariableObservable<TYPE>> NAME = new();";
 
+        public const string ListVariableDictTemplate =
+            "public Dictionary<string, MagicVariableObservable<List<TYPE>>> NAME = new();";
+
         public const string EventDictTemplate = "public Dictionary<string, MagicEventObservable<TYPE>> NAME = new();";
+        public const string ListEventDictTemplate = "public Dictionary<string, MagicEventObservable<List<TYPE>>> NAME = new();";
         public const string EventVoidDictTemplate = "public Dictionary<string, MagicEventVoidObservable> VOID = new();";
 
         public const string VariableGetterTemplate =
             "public static Dictionary<string, MagicVariableObservable<TYPE>> NAME = MagicLinksManager.Instance.NAME;";
 
+        public const string ListVariableGetterTemplate =
+            "public static Dictionary<string, MagicVariableObservable<List<TYPE>>> NAME = MagicLinksManager.Instance.NAME;";
+
         public const string EventGetterTemplate =
             "public static Dictionary<string, MagicEventObservable<TYPE>> SHORT = MagicLinksManager.Instance.NAME;";
+
+        public const string ListEventGetterTemplate =
+            "public static Dictionary<string, MagicEventObservable<List<TYPE>>> SHORT = MagicLinksManager.Instance.NAME;";
 
         public const string EventVoidGetterTemplate =
             "public static Dictionary<string, MagicEventVoidObservable> VOID = MagicLinksManager.Instance.VOID;";
@@ -89,6 +100,7 @@ namespace MagicLinks
         public const string SingleVariableMagicType = "MagicType";
         public const string SingleVariableCategory = "Category";
         public const string SingleVariableType = "Type";
+        public const string SingleVariableIsList = "IsList";
         public const string SingleVariableDeleteButton = "DeleteButton";
 
         public const string CustomTypesFoldout = "CustomTypesFoldout";

--- a/Editor/Various/DynamicVariable.cs
+++ b/Editor/Various/DynamicVariable.cs
@@ -10,6 +10,7 @@ namespace MagicLinks
         public string initialValue;
         public int magicType;
         public string category;
+        public bool isList;
 
         public bool IsEvent()
         {

--- a/Editor/Various/MagicVariablesTemplate.cs
+++ b/Editor/Various/MagicVariablesTemplate.cs
@@ -34,12 +34,14 @@ namespace MagicLinks
             public string key;
             public string type;
             public int magicType;
+            public bool isList;
 
-            public VariableEntry(string key, string type, int magicType)
+            public VariableEntry(string key, string type, int magicType, bool isList)
             {
                 this.key = key;
                 this.type = type;
                 this.magicType = magicType;
+                this.isList = isList;
             }
         }
 
@@ -112,7 +114,7 @@ namespace MagicLinks
             List<DynamicVariable> variables = new List<DynamicVariable>();
             foreach (var v in GetExistingVariables())
             {
-                initialVariables.Add(new VariableEntry(v.vName, v.vLabelType.ToUpper(), v.magicType));
+                initialVariables.Add(new VariableEntry(v.vName, v.vLabelType.ToUpper(), v.magicType, v.isList));
             }
 
             // Feed the variables
@@ -150,7 +152,10 @@ namespace MagicLinks
         
         private string GetDictionaryName(VariableEntry entry)
         {
-            return entry.type.ToUpper() + (entry.magicType == 1 ? MagicLinksConst.EventDict : "");
+            string name = entry.type.ToUpper();
+            if (entry.isList) name += MagicLinksConst.ListDict;
+            if (entry.magicType == 1) name += MagicLinksConst.EventDict;
+            return name;
         }
         
         //STARTUSINGEDITOR


### PR DESCRIPTION
## Summary
- support list variables in Magic Links
- add List dictionary templates and getters
- expose list option in UI

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685bc99724448332b476bd73e719ddfe