### PR TITLE
Remove Odin from listener templates

### DIFF
--- a/Editor/Various/MagicVariablesTemplate.cs
+++ b/Editor/Various/MagicVariablesTemplate.cs
@@ -423,7 +423,7 @@ namespace MagicLinks
             onEventRaised.Invoke(i);
         }
         
-        private IEnumerable<string> GetNames()
+        public IEnumerable<string> GetNames()
         {
             if (_configuration == null || _configuration.typesNamesPairs == null)
                 return new List<string>();
@@ -454,15 +454,15 @@ namespace MagicLinks
             int index = Mathf.Max(0, names.IndexOf(referenceProp.stringValue));
             if (names.Count > 0)
             {
-                index = EditorGUILayout.Popup("Reference", index, names.ToArray());
+                index = UnityEditor.EditorGUILayout.Popup("Reference", index, names.ToArray());
                 referenceProp.stringValue = names[index];
             }
             else
             {
-                referenceProp.stringValue = EditorGUILayout.TextField("Reference", referenceProp.stringValue);
+                referenceProp.stringValue = UnityEditor.EditorGUILayout.TextField("Reference", referenceProp.stringValue);
             }
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("onEventRaised"));
+            UnityEditor.EditorGUILayout.PropertyField(serializedObject.FindProperty("onEventRaised"));
             serializedObject.ApplyModifiedProperties();
         }
     }
@@ -507,7 +507,7 @@ namespace MagicLinks
             onEventRaised.Invoke();
         }
         
-        private IEnumerable<string> GetNames()
+        public IEnumerable<string> GetNames()
         {
             if (_configuration == null || _configuration.typesNamesPairs == null)
                 return new List<string>();
@@ -538,15 +538,15 @@ namespace MagicLinks
             int index = Mathf.Max(0, names.IndexOf(referenceProp.stringValue));
             if (names.Count > 0)
             {
-                index = EditorGUILayout.Popup("Reference", index, names.ToArray());
+                index = UnityEditor.EditorGUILayout.Popup("Reference", index, names.ToArray());
                 referenceProp.stringValue = names[index];
             }
             else
             {
-                referenceProp.stringValue = EditorGUILayout.TextField("Reference", referenceProp.stringValue);
+                referenceProp.stringValue = UnityEditor.EditorGUILayout.TextField("Reference", referenceProp.stringValue);
             }
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("onEventRaised"));
+            UnityEditor.EditorGUILayout.PropertyField(serializedObject.FindProperty("onEventRaised"));
             serializedObject.ApplyModifiedProperties();
         }
     }


### PR DESCRIPTION
## Summary
- drop Odin Inspector usage in listener templates
- add custom inspectors to replicate the dropdown behavior without Odin

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bea212fa483328ecd8618b14ea62d