### PR TITLE
Implement initial value editing for base variables

### DIFF
--- a/Editor/Main/MagicLinksInternalVar.cs
+++ b/Editor/Main/MagicLinksInternalVar.cs
@@ -321,6 +321,30 @@ namespace MagicLinks
                 });
                 field = colorField;
             }
+            else if (type == MagicLinksConst.Vector2)
+            {
+                Vector2Field f = new Vector2Field();
+                Vector2 parsed;
+                if (TryParseVector2(variable.initialValue, out parsed))
+                    f.SetValueWithoutNotify(parsed);
+                f.RegisterValueChangedCallback(v =>
+                {
+                    UpdateDynamicVariableInitialValue(variable, FormatVector2(v.newValue));
+                });
+                field = f;
+            }
+            else if (type == MagicLinksConst.Vector3)
+            {
+                Vector3Field f = new Vector3Field();
+                Vector3 parsed;
+                if (TryParseVector3(variable.initialValue, out parsed))
+                    f.SetValueWithoutNotify(parsed);
+                f.RegisterValueChangedCallback(v =>
+                {
+                    UpdateDynamicVariableInitialValue(variable, FormatVector3(v.newValue));
+                });
+                field = f;
+            }
 
             if (field != null)
             {
@@ -347,6 +371,43 @@ namespace MagicLinks
 
             //AssetDatabase.Refresh();
         }
+
+        private static bool TryParseVector2(string value, out Vector2 result)
+        {
+            result = Vector2.zero;
+            if (string.IsNullOrEmpty(value))
+                return false;
+            var parts = value.Split(',');
+            if (parts.Length != 2)
+                return false;
+            float x, y;
+            if (float.TryParse(parts[0], out x) && float.TryParse(parts[1], out y))
+            {
+                result = new Vector2(x, y);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryParseVector3(string value, out Vector3 result)
+        {
+            result = Vector3.zero;
+            if (string.IsNullOrEmpty(value))
+                return false;
+            var parts = value.Split(',');
+            if (parts.Length != 3)
+                return false;
+            float x, y, z;
+            if (float.TryParse(parts[0], out x) && float.TryParse(parts[1], out y) && float.TryParse(parts[2], out z))
+            {
+                result = new Vector3(x, y, z);
+                return true;
+            }
+            return false;
+        }
+
+        private static string FormatVector2(Vector2 v) => $"{v.x},{v.y}";
+        private static string FormatVector3(Vector3 v) => $"{v.x},{v.y},{v.z}";
 
         public static void OnSingleVariableTypeChanged(DynamicVariable variable, string newType)
         {

--- a/Editor/UI/Variable.uxml
+++ b/Editor/UI/Variable.uxml
@@ -8,6 +8,7 @@
         <engine:Label text="Is List" name="IsListLabel" class="singleVariableElement" />
         <engine:Toggle name="IsList" class="singleVariableElement" />
         <engine:DropdownField name="Category" choices="Player,Enemy" index="0" class="singleVariableElement minSize" />
+        <engine:VisualElement name="InitialValue" class="singleVariableElement minSize" />
         <engine:Button text="x" name="DeleteButton" class="singleVariableElement" style="-unity-font-style: bold; background-color: rgb(188, 71, 71);" />
     </engine:VisualElement>
 </engine:UXML>

--- a/Editor/Utilities/MagicLinksConst.cs
+++ b/Editor/Utilities/MagicLinksConst.cs
@@ -103,6 +103,7 @@ namespace MagicLinks
         public const string SingleVariableIsList = "IsList";
         public const string SingleVariableIsListLabel = "IsListLabel";
         public const string SingleVariableDeleteButton = "DeleteButton";
+        public const string SingleVariableInitialValue = "InitialValue";
 
         public const string CustomTypesFoldout = "CustomTypesFoldout";
         public const string CustomTypeElementName = "CustomTypeName";

--- a/Editor/Various/MagicVariablesTemplate.cs
+++ b/Editor/Various/MagicVariablesTemplate.cs
@@ -54,10 +54,9 @@ namespace MagicLinks
             
             Instance = this;
             
+            //STARTUSINGEDITOR
             
             MagicLinksConfiguration config = MagicLinksUtilities.GetConfiguration();
-            
-            //STARTUSINGEDITOR
             //Create the runtime UI
             if (config.enableRuntimeUI)
             {

--- a/Editor/Various/MagicVariablesTemplate.cs
+++ b/Editor/Various/MagicVariablesTemplate.cs
@@ -348,6 +348,16 @@ namespace MagicLinks
                     return int.Parse(value);
                 if (targetType == typeof(float))
                     return float.Parse(value);
+                if (targetType == typeof(Vector2))
+                {
+                    if (TryParseVector2(value, out var v))
+                        return v;
+                }
+                if (targetType == typeof(Vector3))
+                {
+                    if (TryParseVector3(value, out var v))
+                        return v;
+                }
                 if (targetType == typeof(Color))
                 {
                     Color c;
@@ -358,6 +368,40 @@ namespace MagicLinks
             catch { }
 
             return null;
+        }
+
+        private bool TryParseVector2(string value, out Vector2 result)
+        {
+            result = Vector2.zero;
+            if (string.IsNullOrEmpty(value))
+                return false;
+            var parts = value.Split(',');
+            if (parts.Length != 2)
+                return false;
+            float x, y;
+            if (float.TryParse(parts[0], out x) && float.TryParse(parts[1], out y))
+            {
+                result = new Vector2(x, y);
+                return true;
+            }
+            return false;
+        }
+
+        private bool TryParseVector3(string value, out Vector3 result)
+        {
+            result = Vector3.zero;
+            if (string.IsNullOrEmpty(value))
+                return false;
+            var parts = value.Split(',');
+            if (parts.Length != 3)
+                return false;
+            float x, y, z;
+            if (float.TryParse(parts[0], out x) && float.TryParse(parts[1], out y) && float.TryParse(parts[2], out z))
+            {
+                result = new Vector3(x, y, z);
+                return true;
+            }
+            return false;
         }
         
         private Type GetMagicType(bool isEvent)

--- a/Tests/Editor/ObservablesTests.cs
+++ b/Tests/Editor/ObservablesTests.cs
@@ -53,5 +53,12 @@ namespace MagicLinks.Tests
 
             Assert.AreEqual(1, callCount);
         }
+
+        [Test]
+        public void MagicVariableObservable_InitialValueIsSet()
+        {
+            var observable = new MagicVariableObservable<int>(10);
+            Assert.AreEqual(10, observable.Value);
+        }
     }
 }

--- a/Tests/Editor/ObservablesTests.cs
+++ b/Tests/Editor/ObservablesTests.cs
@@ -60,5 +60,19 @@ namespace MagicLinks.Tests
             var observable = new MagicVariableObservable<int>(10);
             Assert.AreEqual(10, observable.Value);
         }
+
+        [Test]
+        public void MagicVariableObservable_Vector2InitialValueIsSet()
+        {
+            var observable = new MagicVariableObservable<UnityEngine.Vector2>(new UnityEngine.Vector2(1f, 2f));
+            Assert.AreEqual(new UnityEngine.Vector2(1f, 2f), observable.Value);
+        }
+
+        [Test]
+        public void MagicVariableObservable_Vector3InitialValueIsSet()
+        {
+            var observable = new MagicVariableObservable<UnityEngine.Vector3>(new UnityEngine.Vector3(1f, 2f, 3f));
+            Assert.AreEqual(new UnityEngine.Vector3(1f, 2f, 3f), observable.Value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add UI slot for initial values in the editor
- allow editing and saving of initial values for `string`, `bool`, `int`, `float`, and `Color`
- parse initial values when populating dictionaries
- expose `InitialValue` container name constant
- test initial value constructor of `MagicVariableObservable`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685c069edfd883328590c90b1c7e6048